### PR TITLE
Increase Travis CI cache creation timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
 node_js:
   - node
 cache:
+  timeout: 360
   cargo: true
   yarn: true
 script:


### PR DESCRIPTION
Creating the cache is consistently timing out with the default 180 second limit.