### PR TITLE
Have Travis only upload things in the artifacts directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 addons:
   artifacts:
     debug: true
-    working_dir: artifacts
+    paths:
+    - ./artifacts/
     target_paths:
     - /${TRAVIS_OS_NAME}/${TRAVIS_BUILD_NUMBER}


### PR DESCRIPTION
By default the Travis CI artifacts addon will try to upload _every_ untracked file, regardless of the working_dir setting.