### PR TITLE
Create a draft GitHub release from Travis CI when a tag is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
   - bash ./scripts/build.sh
 before_cache:
   - bash ./scripts/before-cache.sh
+before_deploy:
+  - bash ./scripts/before-deploy.sh
 branches:
   only:
   - master
@@ -33,3 +35,13 @@ addons:
     working_dir: artifacts
     target_paths:
     - /${TRAVIS_OS_NAME}/${TRAVIS_BUILD_NUMBER}
+deploy:
+  provider: releases
+  api_key:
+    secure: "CN7/Ntj2O3/4reEVomInoJYoR72BNb58hjDhX1lorI8fNsRLJd1JtDXg6YTsBW/5lgLdlb8qHmtrgnUMeKog70utILgyVFK3+IUg48wt8eNhveRtcGX4VHfjKe/jswFlUT55ZJHMGKPqmV2UjseoSoz45U4A5pMek/yNXziF+t8zQnl52WGi7tchoxnrtMBfCm9o9qAC0AVIuE02v7HP09Bfj1/WfWj6oMB2hIr3OMrkxII4p65jZbYdP82GniQ2UUT4Td5xlVBSnN7FaKpvph3Dnv3GHoPQQlzyD3qpj6ka4y1QpR3sXx1WAf5Op0hwi8X4EadvL6HPLHDbE5eKaLKZBYgoBP8v/Ibdt3u8kW3MA2Kgy6Gk+vvMmZHEvLoXfuBDCzexK17E+BEfqinlth0wVVNs+67U8ClIL6SDLZIy2xSuRBFQZq4tC32mzItAIz2JCOOhFpI2RHAo3zeKcELYgEGjmIXdWAccpe/upngT0KvywGJfwJOM9tKwS9Cc0jEmPTniyLMHoEHl4od9QbLu61oDwM8Psfljn8+WliOGeeuOhZ2kfyEfcNgevTyXwU9z2eJwAaU+vpw8Izp/yvrnnaRWRoGc0EPpWYeDso1PEFQg8X2ShDm/7XoOClbaqHio5mNXNHSaxL4XXgSe0lwFw846MEfopxReaSbXQFo="
+  file_glob: true
+  file: ./artifacts/sd2snes-lttp-rando-tracker-${TRAVIS_OS_NAME}-${TRAVIS_TAG}-${build}.*
+  skip_cleanup: true
+  draft: true
+  on:
+    tags: true

--- a/scripts/before-deploy-linux.sh
+++ b/scripts/before-deploy-linux.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd artifacts
+for build in debug release; do
+  (
+    cd "${build}"
+    tar czvf ../sd2snes-lttp-rando-tracker-"${TRAVIS_OS_NAME}"-"${TRAVIS_TAG}"-"${build}".tar.gz *
+  )
+done

--- a/scripts/before-deploy-macos.sh
+++ b/scripts/before-deploy-macos.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd artifacts
+for build in debug release; do
+  (
+    cd "${build}"
+    tar czvf ../sd2snes-lttp-rando-tracker-"${TRAVIS_OS_NAME}"-"${TRAVIS_TAG}"-"${build}".tar.gz *
+  )
+done

--- a/scripts/before-deploy-windows.sh
+++ b/scripts/before-deploy-windows.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd artifacts
+for build in debug release; do
+  (
+    cd "${build}"
+    zip ../sd2snes-lttp-rando-tracker-"${TRAVIS_OS_NAME}"-"${TRAVIS_TAG}"-"${build}".zip *
+  )
+done

--- a/scripts/before-deploy.sh
+++ b/scripts/before-deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+  bash "${SCRIPT_DIR}/before-deploy-linux.sh"
+fi
+
+if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
+  bash "${SCRIPT_DIR}/before-deploy-windows.sh"
+fi
+
+if [ "${TRAVIS_OS_NAME}" = "osx"     ]; then
+  bash "${SCRIPT_DIR}/before-deploy-macos.sh"
+fi


### PR DESCRIPTION
We now create `.tar.gz`, and `.zip` artifacts for Linux, macOS, and Windows that are automatically uploaded to a draft release on GitHub whenever we push a tag to the repository. This should help streamline the process of releasing a new version of the tracker, especially once Travis CI gets the Windows build/test machines sorted out.