### PR TITLE
Don't run CI for windows on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
-  - windows
   - osx
+#  - windows
 language: rust
 rust:
   - nightly


### PR DESCRIPTION
Travis CI decided that the way to fix their windows issues with secrets was to not filter the output of the secrets at all in the logs, instead of fixing the filtering.

https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/21

Since they're now going to output what the secrets are if we're running on Windows, we can't really run on Windows until they provide a proper fix for the problem.