### PR TITLE
Remove unnecessary feature attribute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ deny(
 )
 ]
 #![feature(
-    try_from,
     plugin,
     proc_macro_hygiene,
     decl_macro


### PR DESCRIPTION
The `try_from` feature has been in stable Rust since 1.34.0, and no longer requires an attribute to enable.  Removing the attribute silences a warning during compilation.