### PR TITLE
Remove macro_use directives in favor of use statements

### DIFF
--- a/src/lttp.rs
+++ b/src/lttp.rs
@@ -24,6 +24,10 @@ use crate::lttp::{
     },
 };
 use failure;
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
 use std::convert::TryFrom;
 
 #[serde(rename_all = "camelCase")]

--- a/src/lttp/item.rs
+++ b/src/lttp/item.rs
@@ -1,4 +1,11 @@
-use failure;
+use failure::{
+    self,
+    format_err,
+};
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
 use std::convert::TryFrom;
 
 #[serde(rename_all = "camelCase")]

--- a/src/lttp/logic.rs
+++ b/src/lttp/logic.rs
@@ -9,6 +9,10 @@ pub use crate::lttp::logic::{
     location_availability::LocationAvailability,
     rule::Rule,
 };
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
 
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Deserialize, Serialize)]

--- a/src/lttp/logic/availability.rs
+++ b/src/lttp/logic/availability.rs
@@ -1,3 +1,8 @@
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
+
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
 pub enum Availability {

--- a/src/lttp/logic/dungeon_availability.rs
+++ b/src/lttp/logic/dungeon_availability.rs
@@ -6,6 +6,10 @@ use crate::lttp::{
     },
     GameState,
 };
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
 
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/lttp/logic/location_availability.rs
+++ b/src/lttp/logic/location_availability.rs
@@ -7,6 +7,10 @@ use crate::lttp::{
     },
     GameState,
 };
+use serde_derive::{
+    Deserialize,
+    Serialize,
+};
 
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/lttp/logic/rule.rs
+++ b/src/lttp/logic/rule.rs
@@ -11,6 +11,9 @@ use crate::{
     },
     GameState,
 };
+use serde_derive::{
+    Deserialize,
+};
 use std::convert::TryInto;
 
 #[serde(rename_all = "camelCase")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,19 +10,6 @@ deny(
 
 mod lttp;
 
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate lazy_panic;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate rocket;
-#[macro_use]
-extern crate serde_derive;
-
 use crate::lttp::{
     logic::RandoLogic,
     Dungeon,
@@ -38,6 +25,9 @@ use bus::{
     BusReader,
 };
 use clap::{
+    crate_authors,
+    crate_description,
+    crate_version,
     App,
     Arg,
     ArgGroup,
@@ -51,11 +41,15 @@ use futures::{
     },
     task,
 };
+use lazy_panic::set_panic_message;
+use lazy_static::lazy_static;
 use rocket::{
+    self,
     config::{
         Config,
         Environment,
     },
+    get,
     http::{
         hyper::{
             header::{
@@ -68,9 +62,13 @@ use rocket::{
         ContentType,
         Status,
     },
+    options,
+    post,
+    routes,
     Response,
 };
 use rocket_contrib::json::Json;
+use serde_derive::Serialize;
 use serde_json;
 use serde_yaml;
 use serial::{
@@ -523,9 +521,9 @@ fn root<'r>() -> Option<Response<'r>> { files(PathBuf::from("")) }
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 pub struct ServerConfig {
-    pub api_port:                    u16,
-    pub websocket_port:              u16,
-    pub logic:                       RandoLogic,
+    pub api_port:       u16,
+    pub websocket_port: u16,
+    pub logic:          RandoLogic,
 }
 
 #[options("/config")]


### PR DESCRIPTION
We can now import macros individually, instead of having to have it be an all-or-nothing thing by using `use crate_name::macro_name;`, instead of `#[macro_use] extern crate crate_name;`